### PR TITLE
fix: 修复AE2WT模组中，无线样板管理终端无法打开的问题

### DIFF
--- a/AE2WTLib Backport/assets/ae2/screens/wtlib/wireless_pattern_access_terminal.json
+++ b/AE2WTLib Backport/assets/ae2/screens/wtlib/wireless_pattern_access_terminal.json
@@ -10,13 +10,5 @@
       "right": 20,
       "grid": "BREAK_AFTER_3COLS"
     }
-  },
-  "widgets": {
-    "toolbox": {
-      "right": 21,
-      "bottom": 90,
-      "width": 59,
-      "height": 66
-    }
   }
 }


### PR DESCRIPTION
Hi,I found that in the AE2WT configuration, the 'toolbox' field under the 'widgets' section in the file related to the Wireless Pattern Access Terminal interface prevents the terminal from opening. Therefore, I have temporarily removed it.

Additionally, I noticed that you uploaded version 2.4.0 of the resource pack on Modrinth, and the changelog mentioned fixing a crash that occurred when clicking the wireless terminal settings. I checked your source code and confirmed that the fix is indeed present there. However, after downloading and extracting the 2.4.0 resource pack, it seems that you may have forgotten to include the fixed code in the uploaded package — because when I load the 2.4.0 resource pack, clicking on Settings still causes a crash.